### PR TITLE
Solve android manifest error when building app in Unity.

### DIFF
--- a/Facebook.Unity.Editor/android/DefaultAndroidManifest.xml
+++ b/Facebook.Unity.Editor/android/DefaultAndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.unity3d.player" android:installLocation="preferExternal" android:versionCode="1" android:versionName="1.0">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools" package="com.unity3d.player" android:installLocation="preferExternal" android:versionCode="1" android:versionName="1.0">
   <supports-screens android:smallScreens="true" android:normalScreens="true" android:largeScreens="true" android:xlargeScreens="true" android:anyDensity="true" />
   <application android:theme="@android:style/Theme.NoTitleBar.Fullscreen" android:icon="@drawable/app_icon" android:label="@string/app_name" android:debuggable="true">
     <activity android:name="com.unity3d.player.UnityPlayerActivity" android:label="@string/app_name">


### PR DESCRIPTION
I met the problem when building Unity app in Android platform with FB sdk version 7.10.1.

![image](https://user-images.githubusercontent.com/3115785/33314961-34cc8196-d46a-11e7-8977-910ccb8c530a.png)

After I refered to the link bellow and added this attribuite in manifest, the build process complete successfully.
reference : https://answers.unity.com/questions/1355793/error-while-saving-blame-file.html

This is the main error
```
Error: The prefix "tools" for attribute "tools:overrideLibrary" associated with an element type "uses-sdk" is not bound.
```

So I want to share the bug and solution here.